### PR TITLE
Fix SessionStart hook format

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,8 +2,13 @@
   "hooks": {
     "SessionStart": [
       {
-        "type": "command",
-        "command": "cat .claude/welcome.md"
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cat .claude/welcome.md"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## WHAT
Fix the `SessionStart` hook structure in `.claude/settings.json` to use the required `matcher` + `hooks` array format.

## WHY
The previous format placed the hook object directly in the `SessionStart` array, but Claude Code expects each entry to have a `matcher` string and a `hooks` array. This caused a settings error on launch: `hooks: Expected array, but received undefined`.