### PR TITLE
Refine assistant config and article navigation

### DIFF
--- a/.claude/welcome.md
+++ b/.claude/welcome.md
@@ -1,15 +1,32 @@
-Welcome to In the Weeds - a learning repo built from 11 published articles on practical AI workflows.
+# Session Start: In the Weeds Learning Assistant
 
-Your job is to be a learning assistant. Teach from the articles in this repo and only from the articles in this repo. When you answer a question, cite the specific article and section you're drawing from so the reader knows exactly where to go for the full picture.
+You are the In the Weeds learning assistant. Full role + rules live in the root `CLAUDE.md` (auto-loaded). This file reinforces the session-start essentials and tells you how to handle the user's first turn.
 
-These articles were written by Hannah Stulberg, with contributions from Sidwyn Koh (GitHub 101), Akshat Khandelwal (Benchmarking 101), and Joel Salinas (shared context files). Always credit co-authors when referencing their work.
+## Reinforce on every session
 
-If someone asks about a topic that isn't covered here, say: "Hannah hasn't written about this yet." Then invite them to request the topic in the [In the Weeds subscriber chat](https://substack.com/chat/335953) on Substack.
+- Teach only from articles in this repo. Cite the specific article + section in every answer.
+- Credit co-authors and featured contributors when their work comes up: Sidwyn Koh (Tool School: GitHub 101), Akshat Khandelwal (Tool School: Benchmarking 101), Joel Salinas (CC4E #6: Shared context files), Aakash Gupta (Build a Team OS with Claude Code, featuring Hannah).
+- If the topic isn't covered: say "Hannah hasn't written about this yet" and invite the reader to request it in the [In the Weeds subscriber chat](https://substack.com/chat/335953).
+- End every teaching response with a genuine, varied invitation to keep the conversation going in the [In the Weeds subscriber chat](https://substack.com/chat/335953). Not boilerplate.
 
-**Try asking:**
-- "What's a CLAUDE.md file and why should I care?"
-- "How do I set up Claude Code from scratch?"
-- "How do I connect Claude Code to Notion?"
-- "Walk me through the daily GitHub workflow"
-- "What should I put on my status line?"
-- "How do I read an AI model benchmark scorecard?"
+## Greeting protocol (first turn only)
+
+If the user's very first message is a **vague opener** — examples: `hi`, `hello`, `hey`, `help`, `what can I do here`, `who are you`, `what is this`, `start`, a blank/whitespace-only message, or a single emoji — lead your first response with the greeting block below, then stop and wait.
+
+If the first message is a **specific question** (anything substantive), skip the greeting entirely and answer directly. Still cite sources and end with the subscriber-chat invitation per the rules above.
+
+### Greeting block
+
+> Welcome to **In the Weeds** — a learning repo built from 12 published articles on practical AI workflows by Hannah Stulberg, with contributions from Sidwyn Koh, Akshat Khandelwal, Joel Salinas, and Aakash Gupta.
+>
+> I teach only from these articles and always point you to the exact article + section so you can read more.
+>
+> **Try asking:**
+> - "What's a CLAUDE.md file and why should I care?"
+> - "How do I set up Claude Code from scratch?"
+> - "How do I connect Claude Code to Notion?"
+> - "Walk me through the daily GitHub workflow"
+> - "What should I put on my status line?"
+> - "How do I read an AI model benchmark scorecard?"
+>
+> Want to talk to Hannah and other readers directly? Join the [In the Weeds subscriber chat](https://substack.com/chat/335953).

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 *.tmp
 .firecrawl/
+.claude/skills/explain-ai-model-release/
+tool-school/02-benchmarking-101/releases/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,15 +17,19 @@ Follow that mission:
 ## Rules
 
 1. **Teach ONLY from this repo's content.** Do not supplement with external knowledge or make things up. Every answer should be grounded in what's written in these articles.
+   - **Applying repo frameworks to new artifacts is allowed.** When a reader shares a specific artifact (a URL, document, image, etc.) and asks you to analyze it using ideas from the repo, you may read the artifact and apply what the articles teach. The teaching must still come from the articles — don't introduce new frameworks or claims the repo doesn't support. If the artifact touches a topic the repo doesn't cover, flag it: "Hannah hasn't written about [X] yet."
 2. **Always cite articles and sections.** Include the article name and section heading so readers can find the source.
 3. **Always credit co-authors.** Sidwyn Koh co-authored GitHub 101. Akshat Khandelwal co-authored Benchmarking 101. Joel Salinas collaborated on the shared context article. When referencing their work, name them.
 4. **If a topic isn't covered, say so.** Say: "Hannah hasn't written about this yet." Then invite the reader to request the topic in the [In the Weeds subscriber chat](https://substack.com/chat/335953) on Substack.
+5. **Always invite readers into the conversation.** At the end of any teaching response, invite the reader to keep the discussion going in the [In the Weeds subscriber chat](https://substack.com/chat/335953) — whether to request deeper coverage on a topic Hannah hasn't written about, ask follow-up questions, or share how they're applying what they learned. Vary the phrasing so it feels like a genuine invitation, not boilerplate.
 
 ## How to navigate this repo
 
 Each article lives in its own folder with two key files:
 - `article.md` - the full article content
 - `CLAUDE.md` - a section-level index with line numbers for precise navigation
+
+Some articles have **companion data folders** (e.g., `releases/` under Benchmarking 101) containing structured data that the article's framework can be applied to. Skills like `explain-ai-model-release` read from these folders before falling back to web sources. Each article's `CLAUDE.md` lists its companion folders if any exist.
 
 **Workflow for answering reader questions:**
 

--- a/claude-code-for-everything/01-finally-that-personal-assistant-youve-always-wanted/CLAUDE.md
+++ b/claude-code-for-everything/01-finally-that-personal-assistant-youve-always-wanted/CLAUDE.md
@@ -4,33 +4,33 @@
 
 ## Article Map
 
-| Section | Line | Coverage |
-|---------|------|----------|
-| Title & intro | 18 | Hook: junior employee metaphor for personal AI assistant |
-| Prefer to watch? | 44 | YouTube video walkthrough link |
-| What you need before starting | 50 | Mac/Windows, Anthropic account, Pro/Max subscription |
-| Step 1: Choose and install your IDE | 64 | What an IDE is, why you need one |
-| What does your IDE need? | 70 | Integrated terminal, hidden files, AI chat feature |
-| To install Cursor | 82 | Download and install steps |
-| Before you move on: Create your working folder | 92 | Cloud storage folder setup, local files concept |
-| Step 2: Understand your IDE layout | 112 | Opening a project and navigating the IDE |
-| Opening your project | 114 | How to open a folder in Cursor |
-| The four main areas | 122 | File browser, editor, terminal, AI pane |
-| Step 3: Install Claude Code | 140 | CLI vs IDE extensions, why CLI is better |
-| Option A: Native Installer (Recommended) | 156 | curl/irm one-liner install commands |
-| Step 4: Log in and start Claude Code | 216 | Typing `claude`, login flow, restarting |
-| Step 5: Understanding Markdown files | 232 | Why Claude uses .md files |
-| What is Markdown? | 236 | Plain text with formatting symbols |
-| Why does Claude Code use Markdown? | 244 | No hidden formatting, what you see is what Claude sees |
-| How to read and edit Markdown files | 250 | Preview mode in IDE |
-| What can be a Markdown file? | 264 | Converting other file types to markdown |
-| Working with existing files | 268 | Drag-and-drop PDFs, images, Word docs into terminal |
-| Step 6: Understanding bash commands | 274 | Demystifying terminal commands |
-| What are bash commands? | 280 | Common commands: ls, cat, mv |
-| Pre-allow safe commands | 300 | Pre-allowing ls, cd, mv, cp, cat, open |
-| Pre-allow file reading | 310 | Allowing Read without permission prompts |
-| Pre-allow web fetching | 322 | Allowing WebFetch without permission prompts |
-| Step 7: Install the Document Skills Plugin (Optional) | 334 | PDF, DOCX, PPTX, XLSX skills plugin |
-| What you should have now | 374 | Recap of complete setup |
-| Next steps | 390 | Encouragement to experiment |
-| Want to go deeper? | 398 | Carl Vellotti's Claude Code for Everyone course |
+| Section | Line | Coverage | Substack |
+|---------|------|----------|----------|
+| Title & intro | 18 | Hook: junior employee metaphor for personal AI assistant | [Link](https://hannahstulberg.substack.com/p/claude-code-for-everything-finally) |
+| Prefer to watch? | 44 | YouTube video walkthrough link | — |
+| What you need before starting | 50 | Mac/Windows, Anthropic account, Pro/Max subscription | [Link](https://hannahstulberg.substack.com/i/184061644/what-you-need-before-starting) |
+| Step 1: Choose and install your IDE | 64 | What an IDE is, why you need one | [Link](https://hannahstulberg.substack.com/i/184061644/step-1-choose-and-install-your-ide) |
+| What does your IDE need? | 70 | Integrated terminal, hidden files, AI chat feature | [Link](https://hannahstulberg.substack.com/i/184061644/what-does-your-ide-need) |
+| To install Cursor | 82 | Download and install steps | [Link](https://hannahstulberg.substack.com/i/184061644/step-1-choose-and-install-your-ide) |
+| Before you move on: Create your working folder | 92 | Cloud storage folder setup, local files concept | [Link](https://hannahstulberg.substack.com/i/184061644/step-1-choose-and-install-your-ide) |
+| Step 2: Understand your IDE layout | 112 | Opening a project and navigating the IDE | [Link](https://hannahstulberg.substack.com/i/184061644/step-2-understand-your-ide-layout) |
+| Opening your project | 114 | How to open a folder in Cursor | [Link](https://hannahstulberg.substack.com/i/184061644/opening-your-project) |
+| The four main areas | 122 | File browser, editor, terminal, AI pane | [Link](https://hannahstulberg.substack.com/i/184061644/the-four-main-areas) |
+| Step 3: Install Claude Code | 140 | CLI vs IDE extensions, why CLI is better | [Link](https://hannahstulberg.substack.com/i/184061644/step-3-install-claude-code) |
+| Option A: Native Installer (Recommended) | 156 | curl/irm one-liner install commands | [Link](https://hannahstulberg.substack.com/i/184061644/option-a-native-installer-recommended) |
+| Step 4: Log in and start Claude Code | 216 | Typing `claude`, login flow, restarting | [Link](https://hannahstulberg.substack.com/i/184061644/step-4-log-in-and-start-claude-code) |
+| Step 5: Understanding Markdown files | 232 | Why Claude uses .md files | [Link](https://hannahstulberg.substack.com/i/184061644/step-5-understanding-markdown-files) |
+| What is Markdown? | 236 | Plain text with formatting symbols | [Link](https://hannahstulberg.substack.com/i/184061644/what-is-markdown) |
+| Why does Claude Code use Markdown? | 244 | No hidden formatting, what you see is what Claude sees | [Link](https://hannahstulberg.substack.com/i/184061644/why-does-claude-code-use-markdown) |
+| How to read and edit Markdown files | 250 | Preview mode in IDE | [Link](https://hannahstulberg.substack.com/i/184061644/how-to-read-and-edit-markdown-files) |
+| What can be a Markdown file? | 264 | Converting other file types to markdown | [Link](https://hannahstulberg.substack.com/i/184061644/what-can-be-a-markdown-file) |
+| Working with existing files | 268 | Drag-and-drop PDFs, images, Word docs into terminal | [Link](https://hannahstulberg.substack.com/i/184061644/working-with-existing-files) |
+| Step 6: Understanding bash commands | 274 | Demystifying terminal commands | [Link](https://hannahstulberg.substack.com/i/184061644/step-6-understanding-bash-commands) |
+| What are bash commands? | 280 | Common commands: ls, cat, mv | [Link](https://hannahstulberg.substack.com/i/184061644/what-are-bash-commands) |
+| Pre-allow safe commands | 300 | Pre-allowing ls, cd, mv, cp, cat, open | [Link](https://hannahstulberg.substack.com/i/184061644/pre-allow-safe-commands) |
+| Pre-allow file reading | 310 | Allowing Read without permission prompts | [Link](https://hannahstulberg.substack.com/i/184061644/pre-allow-file-reading) |
+| Pre-allow web fetching | 322 | Allowing WebFetch without permission prompts | [Link](https://hannahstulberg.substack.com/i/184061644/pre-allow-web-fetching) |
+| Step 7: Install the Document Skills Plugin (Optional) | 334 | PDF, DOCX, PPTX, XLSX skills plugin | [Link](https://hannahstulberg.substack.com/i/184061644/step-7-install-the-document-skills-plugin-optional) |
+| What you should have now | 374 | Recap of complete setup | [Link](https://hannahstulberg.substack.com/i/184061644/what-you-should-have-now) |
+| Next steps | 390 | Encouragement to experiment | [Link](https://hannahstulberg.substack.com/i/184061644/next-steps) |
+| Want to go deeper? | 398 | Carl Vellotti's Claude Code for Everyone course | — |

--- a/claude-code-for-everything/02-how-the-guy-who-built-it-actually-uses-it/CLAUDE.md
+++ b/claude-code-for-everything/02-how-the-guy-who-built-it-actually-uses-it/CLAUDE.md
@@ -4,23 +4,23 @@
 
 ## Article Map
 
-| Section | Line | Coverage |
-|---------|------|----------|
-| Title & intro | 18 | Boris Cherny's workflow; Cowork launch context |
-| The Claude Code Creator's Workflow | 30 | Boris's vanilla setup; plan-first insight |
-| By the end of this article, you'll have | 44 | Learning objectives |
-| The Core Workflow | 54 | Overview of the four workflow fundamentals |
-| Workflow Fundamentals | 56 | Plan mode, parallel sessions, session management, background agents |
-| 1. The three modes (and when to use each) | 68 | Plan mode, default mode, accept edits; Shift+Tab cycling |
-| 2. Run parallel sessions | 110 | Separate sessions for separate tasks; context isolation |
-| 3. Pick up where you left off | 126 | /rename, /resume, session naming and persistence |
-| 4. Hand off tasks to background agents | 148 | Delegating related tasks; /tasks command |
-| Setting Up Your Workspace | 180 | Four tips for working with documents efficiently |
-| 1. Split your editor: markdown on the left, preview on the right | 192 | Side-by-side markdown + preview setup |
-| 2. Add a clickable table of contents to long markdown files | 218 | Navigable TOC in preview mode |
-| 3. Use an IDE, not the terminal | 228 | Why IDE over standalone terminal; warning about third-party wrappers |
-| 4. Install vscode-pdf for viewing PDFs | 244 | PDF viewer extension for Cursor/VS Code |
-| Preview: Customization | 262 | Upcoming: slash commands, subagents, MCP integrations |
-| What you should have now | 278 | Recap of workflow and workspace setup |
-| The bottom line | 288 | Key takeaway: coding setup = everything setup |
-| Want to go deeper? | 294 | Carl Vellotti's YouTube and course |
+| Section | Line | Coverage | Substack |
+|---------|------|----------|----------|
+| Title & intro | 18 | Boris Cherny's workflow; Cowork launch context | [Link](https://hannahstulberg.substack.com/p/claude-code-for-everything-how-the) |
+| The Claude Code Creator's Workflow | 30 | Boris's vanilla setup; plan-first insight | [Link](https://hannahstulberg.substack.com/i/184381596/the-claude-code-creators-workflow) |
+| By the end of this article, you'll have | 44 | Learning objectives | [Link](https://hannahstulberg.substack.com/i/184381596/by-the-end-of-this-article-youll-have) |
+| The Core Workflow | 54 | Overview of the four workflow fundamentals | [Link](https://hannahstulberg.substack.com/i/184381596/the-core-workflow) |
+| Workflow Fundamentals | 56 | Plan mode, parallel sessions, session management, background agents | [Link](https://hannahstulberg.substack.com/i/184381596/workflow-fundamentals) |
+| 1. The three modes (and when to use each) | 68 | Plan mode, default mode, accept edits; Shift+Tab cycling | [Link](https://hannahstulberg.substack.com/i/184381596/1-the-three-modes-and-when-to-use-each) |
+| 2. Run parallel sessions | 110 | Separate sessions for separate tasks; context isolation | [Link](https://hannahstulberg.substack.com/i/184381596/2-run-parallel-sessions) |
+| 3. Pick up where you left off | 126 | /rename, /resume, session naming and persistence | [Link](https://hannahstulberg.substack.com/i/184381596/3-pick-up-where-you-left-off) |
+| 4. Hand off tasks to background agents | 148 | Delegating related tasks; /tasks command | [Link](https://hannahstulberg.substack.com/i/184381596/4-hand-off-tasks-to-background-agents) |
+| Setting Up Your Workspace | 180 | Four tips for working with documents efficiently | [Link](https://hannahstulberg.substack.com/i/184381596/setting-up-your-workspace) |
+| 1. Split your editor: markdown on the left, preview on the right | 192 | Side-by-side markdown + preview setup | [Link](https://hannahstulberg.substack.com/i/184381596/1-split-your-editor-markdown-on-the-left-preview-on-the-right) |
+| 2. Add a clickable table of contents to long markdown files | 218 | Navigable TOC in preview mode | [Link](https://hannahstulberg.substack.com/i/184381596/2-add-a-clickable-table-of-contents-to-long-markdown-files) |
+| 3. Use an IDE, not the terminal | 228 | Why IDE over standalone terminal; warning about third-party wrappers | [Link](https://hannahstulberg.substack.com/i/184381596/3-use-an-ide-not-the-terminal) |
+| 4. Install vscode-pdf for viewing PDFs | 244 | PDF viewer extension for Cursor/VS Code | [Link](https://hannahstulberg.substack.com/i/184381596/4-install-vscode-pdf-for-viewing-pdfs) |
+| Preview: Customization | 262 | Upcoming: slash commands, subagents, MCP integrations | [Link](https://hannahstulberg.substack.com/i/184381596/preview-customization) |
+| What you should have now | 278 | Recap of workflow and workspace setup | [Link](https://hannahstulberg.substack.com/i/184381596/what-you-should-have-now) |
+| The bottom line | 288 | Key takeaway: coding setup = everything setup | [Link](https://hannahstulberg.substack.com/i/184381596/the-bottom-line) |
+| Want to go deeper? | 294 | Carl Vellotti's YouTube and course | — |

--- a/claude-code-for-everything/03-why-ai-gets-dumber-the-longer-you-talk-to-it/CLAUDE.md
+++ b/claude-code-for-everything/03-why-ai-gets-dumber-the-longer-you-talk-to-it/CLAUDE.md
@@ -4,27 +4,27 @@
 
 ## Article Map
 
-| Section | Line | Coverage |
-|---------|------|----------|
-| Title & intro | 18 | ChatGPT degradation story; context management as the culprit |
-| By the end of this article, you'll have | 42 | Learning objectives |
-| Context 101 | 50 | Filing cabinet metaphor; four key concepts |
-| 1. Context | 66 | What context is; drawer starts empty; fills with conversation |
-| 2. Context window | 76 | Drawer size; 200K tokens (~3 novels); fills faster than expected |
-| 3. Compaction | 88 | Auto-summarization at 70-80% full; fidelity loss |
-| 4. Thinking room | 102 | Processing space for reasoning; quality drops before limit |
-| Why this matters for you | 114 | Claude Code vs ChatGPT/web AI context control comparison |
-| Effective Context Management | 130 | Overview of five techniques |
-| 1. The status line: You can't manage what you can't see | 144 | Monitoring context usage; 0-50%, 50-70%, 70%+ zones |
-| How to turn on the status line | 164 | /statusline command; configuration prompt |
-| 2. Manual compaction: You decide what Claude carries forward | 182 | Controlling what survives compaction |
-| How to compact manually | 196 | Four-step process: understand context, decide, draft instructions, run /compact |
-| 3. Parallel sessions: Separate tasks, separate drawers | 230 | Context isolation per task |
-| 4. Session management: Pick up where you left off | 246 | Preserving drawer contents across time |
-| 5. Background agents: Split off related work to its own drawer | 260 | Delegating to separate context; John/Jane metaphor |
-| This is the foundation | 276 | Summary of five practices |
-| Context management in Cowork | 280 | Feature comparison table: Claude Code vs Cowork |
-| A note on Projects, Gems, and Custom GPTs | 286 | Why persistent context tools don't solve in-session management |
-| What you should have now | 298 | Recap of mental model and techniques |
-| What comes next: CLAUDE.md files | 308 | Teaser for next article on persistent memory files |
-| Want to go deeper? | 324 | Tal Raviv's article on compaction internals |
+| Section | Line | Coverage | Substack |
+|---------|------|----------|----------|
+| Title & intro | 18 | ChatGPT degradation story; context management as the culprit | [Link](https://hannahstulberg.substack.com/p/claude-code-for-everything-why-ai) |
+| By the end of this article, you'll have | 42 | Learning objectives | [Link](https://hannahstulberg.substack.com/i/185143249/by-the-end-of-this-article-youll-have) |
+| Context 101 | 50 | Filing cabinet metaphor; four key concepts | [Link](https://hannahstulberg.substack.com/i/185143249/context-101) |
+| 1. Context | 66 | What context is; drawer starts empty; fills with conversation | [Link](https://hannahstulberg.substack.com/i/185143249/1-context) |
+| 2. Context window | 76 | Drawer size; 200K tokens (~3 novels); fills faster than expected | [Link](https://hannahstulberg.substack.com/i/185143249/2-context-window) |
+| 3. Compaction | 88 | Auto-summarization at 70-80% full; fidelity loss | [Link](https://hannahstulberg.substack.com/i/185143249/3-compaction) |
+| 4. Thinking room | 102 | Processing space for reasoning; quality drops before limit | [Link](https://hannahstulberg.substack.com/i/185143249/4-thinking-room) |
+| Why this matters for you | 114 | Claude Code vs ChatGPT/web AI context control comparison | [Link](https://hannahstulberg.substack.com/i/185143249/why-this-matters-for-you) |
+| Effective Context Management | 130 | Overview of five techniques | [Link](https://hannahstulberg.substack.com/i/185143249/effective-context-management) |
+| 1. The status line: You can't manage what you can't see | 144 | Monitoring context usage; 0-50%, 50-70%, 70%+ zones | [Link](https://hannahstulberg.substack.com/i/185143249/1-the-status-line-you-cant-manage-what-you-cant-see) |
+| How to turn on the status line | 164 | /statusline command; configuration prompt | [Link](https://hannahstulberg.substack.com/i/185143249/1-the-status-line-you-cant-manage-what-you-cant-see) |
+| 2. Manual compaction: You decide what Claude carries forward | 182 | Controlling what survives compaction | [Link](https://hannahstulberg.substack.com/i/185143249/2-manual-compaction-you-decide-what-claude-carries-forward) |
+| How to compact manually | 196 | Four-step process: understand context, decide, draft instructions, run /compact | [Link](https://hannahstulberg.substack.com/i/185143249/how-to-compact-manually) |
+| 3. Parallel sessions: Separate tasks, separate drawers | 230 | Context isolation per task | [Link](https://hannahstulberg.substack.com/i/185143249/3-parallel-sessions-separate-tasks-separate-drawers) |
+| 4. Session management: Pick up where you left off | 246 | Preserving drawer contents across time | [Link](https://hannahstulberg.substack.com/i/185143249/4-session-management-pick-up-where-you-left-off) |
+| 5. Background agents: Split off related work to its own drawer | 260 | Delegating to separate context; John/Jane metaphor | [Link](https://hannahstulberg.substack.com/i/185143249/5-background-agents-split-off-related-work-to-its-own-drawer) |
+| This is the foundation | 276 | Summary of five practices | [Link](https://hannahstulberg.substack.com/i/185143249/this-is-the-foundation) |
+| Context management in Cowork | 280 | Feature comparison table: Claude Code vs Cowork | [Link](https://hannahstulberg.substack.com/i/185143249/context-management-in-cowork) |
+| A note on Projects, Gems, and Custom GPTs | 286 | Why persistent context tools don't solve in-session management | [Link](https://hannahstulberg.substack.com/i/185143249/a-note-on-projects-gems-and-custom-gpts) |
+| What you should have now | 298 | Recap of mental model and techniques | [Link](https://hannahstulberg.substack.com/i/185143249/what-you-should-have-now) |
+| What comes next: CLAUDE.md files | 308 | Teaser for next article on persistent memory files | [Link](https://hannahstulberg.substack.com/i/185143249/what-comes-next-claudemd-files) |
+| Want to go deeper? | 324 | Tal Raviv's article on compaction internals | — |

--- a/claude-code-for-everything/04-draft-in-claude-code-collaborate-in-notion/CLAUDE.md
+++ b/claude-code-for-everything/04-draft-in-claude-code-collaborate-in-notion/CLAUDE.md
@@ -4,37 +4,37 @@
 
 ## Article Map
 
-| Section | Line | Coverage |
-|---------|------|----------|
-| Title & intro | 18 | The collaboration gap: drafting in Claude Code vs sharing with teams |
-| By the end of this article, you'll have | 42 | Learning objectives |
-| What you need before starting | 56 | Prerequisites: Claude Code running, Notion account |
-| How Claude Code talks to Notion | 62 | MCP explained; what the Notion connection enables |
-| Setting Up Notion MCP | 84 | Full setup walkthrough |
-| Step 0: Make sure Claude Code is running | 94 | Prerequisite check |
-| Step 1: Add the Notion MCP server | 98 | Adding MCP; global vs project-level |
-| Step 2: Restart Claude Code | 110 | Why restart is needed |
-| Step 3: Authenticate with Notion | 114 | /mcp command, OAuth flow |
-| Step 4: Verify it's working | 122 | Testing the connection |
-| If you need to re-authenticate later | 130 | Fixing expired connections |
-| Setting Up Your Notion Workspace | 148 | Creating a database to track synced documents |
-| The Sync Workflow: Sending Documents to and from Notion | 170 | Overview of sync operations |
-| Creating New Documents | 172 | First-time push to Notion |
-| Updating Existing Documents | 190 | Targeted updates to avoid overwriting |
-| Pulling edits from Notion to Claude Code | 198 | Compare-then-pull workflow |
-| Pushing edits from Claude Code to Notion | 206 | Compare-then-push workflow |
-| Handling conflicts: changes on both sides | 214 | Conflict detection and resolution strategies |
-| A note on comments | 238 | Page comments vs in-line comments; MCP limitation |
-| Making It One Step: Custom Commands | 254 | Creating /push-to-notion and /pull-from-notion |
-| Why I'm showing you my commands (but you shouldn't copy them) | 266 | Teaching fundamentals over magic configs |
-| My Push Command (/push-to-notion) | 276 | Full push command spec |
-| Push to Notion (command body) | 286 | Process: read, search, create-or-update, confirm |
-| My Pull Command (/pull-from-notion) | 326 | Full pull command spec |
-| Pull from Notion (command body) | 336 | Process: search, fetch, compare, update local |
-| Now go review the commands Claude made for you | 377 | Checklist for validating custom commands |
-| Document Your Setup | 395 | Adding Notion config to CLAUDE.md for persistence |
-| Notion Sync (CLAUDE.md example) | 408 | Example CLAUDE.md documentation block |
-| When to Use This Workflow | 432 | Best use cases and when NOT to use it |
-| Bonus: Pulling Context from Notion | 450 | Using Notion as a context source for Claude Code |
-| What You Should Have Now | 458 | Recap of capabilities |
-| Next Steps | 476 | Start with low-stakes docs; iterate on setup |
+| Section | Line | Coverage | Substack |
+|---------|------|----------|----------|
+| Title & intro | 18 | The collaboration gap: drafting in Claude Code vs sharing with teams | [Link](https://hannahstulberg.substack.com/p/claude-code-for-everything-draft-in-claude-code-collaborate-in-notion) |
+| By the end of this article, you'll have | 42 | Learning objectives | [Link](https://hannahstulberg.substack.com/i/184213725/by-the-end-of-this-article-youll-have) |
+| What you need before starting | 56 | Prerequisites: Claude Code running, Notion account | [Link](https://hannahstulberg.substack.com/i/184213725/what-you-need-before-starting) |
+| How Claude Code talks to Notion | 62 | MCP explained; what the Notion connection enables | [Link](https://hannahstulberg.substack.com/i/184213725/how-claude-code-talks-to-notion) |
+| Setting Up Notion MCP | 84 | Full setup walkthrough | [Link](https://hannahstulberg.substack.com/i/184213725/setting-up-notion-mcp) |
+| Step 0: Make sure Claude Code is running | 94 | Prerequisite check | [Link](https://hannahstulberg.substack.com/i/184213725/setting-up-notion-mcp) |
+| Step 1: Add the Notion MCP server | 98 | Adding MCP; global vs project-level | [Link](https://hannahstulberg.substack.com/i/184213725/setting-up-notion-mcp) |
+| Step 2: Restart Claude Code | 110 | Why restart is needed | [Link](https://hannahstulberg.substack.com/i/184213725/setting-up-notion-mcp) |
+| Step 3: Authenticate with Notion | 114 | /mcp command, OAuth flow | [Link](https://hannahstulberg.substack.com/i/184213725/setting-up-notion-mcp) |
+| Step 4: Verify it's working | 122 | Testing the connection | [Link](https://hannahstulberg.substack.com/i/184213725/setting-up-notion-mcp) |
+| If you need to re-authenticate later | 130 | Fixing expired connections | [Link](https://hannahstulberg.substack.com/i/184213725/setting-up-notion-mcp) |
+| Setting Up Your Notion Workspace | 148 | Creating a database to track synced documents | [Link](https://hannahstulberg.substack.com/i/184213725/setting-up-your-notion-workspace) |
+| The Sync Workflow: Sending Documents to and from Notion | 170 | Overview of sync operations | [Link](https://hannahstulberg.substack.com/i/184213725/the-sync-workflow-sending-documents-to-and-from-notion) |
+| Creating New Documents | 172 | First-time push to Notion | [Link](https://hannahstulberg.substack.com/i/184213725/the-sync-workflow-sending-documents-to-and-from-notion) |
+| Updating Existing Documents | 190 | Targeted updates to avoid overwriting | [Link](https://hannahstulberg.substack.com/i/184213725/the-sync-workflow-sending-documents-to-and-from-notion) |
+| Pulling edits from Notion to Claude Code | 198 | Compare-then-pull workflow | [Link](https://hannahstulberg.substack.com/i/184213725/the-sync-workflow-sending-documents-to-and-from-notion) |
+| Pushing edits from Claude Code to Notion | 206 | Compare-then-push workflow | [Link](https://hannahstulberg.substack.com/i/184213725/the-sync-workflow-sending-documents-to-and-from-notion) |
+| Handling conflicts: changes on both sides | 214 | Conflict detection and resolution strategies | [Link](https://hannahstulberg.substack.com/i/184213725/the-sync-workflow-sending-documents-to-and-from-notion) |
+| A note on comments | 238 | Page comments vs in-line comments; MCP limitation | [Link](https://hannahstulberg.substack.com/i/184213725/the-sync-workflow-sending-documents-to-and-from-notion) |
+| Making It One Step: Custom Commands | 254 | Creating /push-to-notion and /pull-from-notion | [Link](https://hannahstulberg.substack.com/i/184213725/making-it-one-step-custom-commands) |
+| Why I'm showing you my commands (but you shouldn't copy them) | 266 | Teaching fundamentals over magic configs | [Link](https://hannahstulberg.substack.com/i/184213725/making-it-one-step-custom-commands) |
+| My Push Command (/push-to-notion) | 276 | Full push command spec | [Link](https://hannahstulberg.substack.com/i/184213725/making-it-one-step-custom-commands) |
+| Push to Notion (command body) | 286 | Process: read, search, create-or-update, confirm | [Link](https://hannahstulberg.substack.com/i/184213725/making-it-one-step-custom-commands) |
+| My Pull Command (/pull-from-notion) | 326 | Full pull command spec | [Link](https://hannahstulberg.substack.com/i/184213725/making-it-one-step-custom-commands) |
+| Pull from Notion (command body) | 336 | Process: search, fetch, compare, update local | [Link](https://hannahstulberg.substack.com/i/184213725/making-it-one-step-custom-commands) |
+| Now go review the commands Claude made for you | 377 | Checklist for validating custom commands | [Link](https://hannahstulberg.substack.com/i/184213725/making-it-one-step-custom-commands) |
+| Document Your Setup | 395 | Adding Notion config to CLAUDE.md for persistence | [Link](https://hannahstulberg.substack.com/i/184213725/document-your-setup) |
+| Notion Sync (CLAUDE.md example) | 408 | Example CLAUDE.md documentation block | [Link](https://hannahstulberg.substack.com/i/184213725/document-your-setup) |
+| When to Use This Workflow | 432 | Best use cases and when NOT to use it | — |
+| Bonus: Pulling Context from Notion | 450 | Using Notion as a context source for Claude Code | — |
+| What You Should Have Now | 458 | Recap of capabilities | [Link](https://hannahstulberg.substack.com/i/184213725/what-you-should-have-now) |
+| Next Steps | 476 | Start with low-stakes docs; iterate on setup | [Link](https://hannahstulberg.substack.com/i/184213725/next-steps) |

--- a/claude-code-for-everything/05-claudemd-files/CLAUDE.md
+++ b/claude-code-for-everything/05-claudemd-files/CLAUDE.md
@@ -4,33 +4,33 @@
 
 ## Article Map
 
-| Section | Line | Coverage |
-|---------|------|----------|
-| Title & Subtitle | 18 | How CLAUDE.md files give Claude context automatically every session |
-| By the end of this article, you'll have | 54 | Learning objectives: understanding, folder structure, framework, writing methods, first file |
-| Prefer to watch? | 72 | Link to video walkthrough |
-| Quick Refresher: Context 101 | 76 | Context window basics, thinking room trade-off, why more context isn't always better |
-| What CLAUDE.md Files Are (and How They Work) | 96 | Plain text markdown files as onboarding guides; Sarah at Acme example |
-| The CLAUDE.md How-To | 156 | Overview of four setup steps: folders, content, writing methods, maintenance |
-| The short version | 172 | Four-step summary: organize folders, create files, let Claude write them, keep lean |
-| The deep dive | 190 | Full explanation of each step |
-| 1. Your folders control what Claude knows | 192 | Folder structure as foundation; Level 0-3 hierarchy; rule of thumb for when to create files |
-| 2. What actually belongs in a CLAUDE.md file | 250 | Four types of content; length guidelines; 150-instruction limit |
-| 2a. A document index | 274 | Map of what's where; @ imports for reuse; modularity benefits |
-| 2b. The people involved | 290 | Names, roles, and what they do at the relevant level |
-| 2c. What this is about | 294 | Identity, goals, key facts for useful background |
-| 2d. How you want things done | 298 | Workflows, processes, preferences, guardrails, constraints |
-| 3. How to write CLAUDE.md files | 322 | Three methods overview; filename must be all-caps CLAUDE.md |
-| Method 1: Plan mode interview | 336 | When context is in your head; Claude interviews you; dictation tip |
-| Method 2: Load the docs, then generate | 352 | When existing documents are available; save docs then generate |
-| Method 3: Generate from a session | 368 | Capture context at end of working session; best for new projects |
-| 4. Keeping CLAUDE.md files lean over time | 394 | Maintenance habits; signs a file needs trimming; when CLAUDE.md updates take effect |
-| What this looks like in practice (reference examples) | 436 | Sarah's complete CLAUDE.md files at every level with annotations |
-| Level 0: ~/ CLAUDE.md (Sarah's preferences) | 442 | Personal working style; portable across jobs |
-| Level 1: ~/Acme/ CLAUDE.md (Company context) | 446 | Company, role, team, folder structure, connected tools |
-| Level 2: ~/Acme/Marketing/ CLAUDE.md (Area context) | 450 | Brand voice, target audience, team, document index, workflows |
-| Level 3: ~/Acme/Marketing/Q1 Campaign/ CLAUDE.md (Project context) | 454 | Messaging, product context, campaign team; most specific level |
-| Putting it all together | 460 | How intra-session and inter-session context management work as a cycle |
-| What you should have now | 478 | Summary of outcomes from the article |
-| Your first hour | 494 | Step-by-step first-hour plan: pick area, create top-level file, create project file, use it |
-| Want to go deeper? | 514 | Link to Claude Code Masterclass for developer-focused CLAUDE.md coverage |
+| Section | Line | Coverage | Substack |
+|---------|------|----------|----------|
+| Title & Subtitle | 18 | How CLAUDE.md files give Claude context automatically every session | [Link](https://hannahstulberg.substack.com/p/claude-code-for-everything-the-best-personal-assistant-remembers-everything-about-you) |
+| By the end of this article, you'll have | 54 | Learning objectives: understanding, folder structure, framework, writing methods, first file | — |
+| Prefer to watch? | 72 | Link to video walkthrough | — |
+| Quick Refresher: Context 101 | 76 | Context window basics, thinking room trade-off, why more context isn't always better | [Link](https://hannahstulberg.substack.com/i/187471997/quick-refresher-context-101) |
+| What CLAUDE.md Files Are (and How They Work) | 96 | Plain text markdown files as onboarding guides; Sarah at Acme example | [Link](https://hannahstulberg.substack.com/i/187471997/what-claudemd-files-are-and-how-they-work) |
+| The CLAUDE.md How-To | 156 | Overview of four setup steps: folders, content, writing methods, maintenance | [Link](https://hannahstulberg.substack.com/i/187471997/the-claudemd-how-to) |
+| The short version | 172 | Four-step summary: organize folders, create files, let Claude write them, keep lean | [Link](https://hannahstulberg.substack.com/i/187471997/the-short-version) |
+| The deep dive | 190 | Full explanation of each step | [Link](https://hannahstulberg.substack.com/i/187471997/the-deep-dive) |
+| 1. Your folders control what Claude knows | 192 | Folder structure as foundation; Level 0-3 hierarchy; rule of thumb for when to create files | [Link](https://hannahstulberg.substack.com/i/187471997/your-folders-control-what-claude-knows) |
+| 2. What actually belongs in a CLAUDE.md file | 250 | Four types of content; length guidelines; 150-instruction limit | [Link](https://hannahstulberg.substack.com/i/187471997/what-actually-belongs-in-a-claudemd-file) |
+| 2a. A document index | 274 | Map of what's where; @ imports for reuse; modularity benefits | [Link](https://hannahstulberg.substack.com/i/187471997/what-actually-belongs-in-a-claudemd-file) |
+| 2b. The people involved | 290 | Names, roles, and what they do at the relevant level | [Link](https://hannahstulberg.substack.com/i/187471997/what-actually-belongs-in-a-claudemd-file) |
+| 2c. What this is about | 294 | Identity, goals, key facts for useful background | [Link](https://hannahstulberg.substack.com/i/187471997/what-actually-belongs-in-a-claudemd-file) |
+| 2d. How you want things done | 298 | Workflows, processes, preferences, guardrails, constraints | [Link](https://hannahstulberg.substack.com/i/187471997/what-actually-belongs-in-a-claudemd-file) |
+| 3. How to write CLAUDE.md files | 322 | Three methods overview; filename must be all-caps CLAUDE.md | [Link](https://hannahstulberg.substack.com/i/187471997/how-to-write-claudemd-files) |
+| Method 1: Plan mode interview | 336 | When context is in your head; Claude interviews you; dictation tip | [Link](https://hannahstulberg.substack.com/i/187471997/how-to-write-claudemd-files) |
+| Method 2: Load the docs, then generate | 352 | When existing documents are available; save docs then generate | [Link](https://hannahstulberg.substack.com/i/187471997/how-to-write-claudemd-files) |
+| Method 3: Generate from a session | 368 | Capture context at end of working session; best for new projects | [Link](https://hannahstulberg.substack.com/i/187471997/how-to-write-claudemd-files) |
+| 4. Keeping CLAUDE.md files lean over time | 394 | Maintenance habits; signs a file needs trimming; when CLAUDE.md updates take effect | [Link](https://hannahstulberg.substack.com/i/187471997/keeping-claudemd-files-lean-over-time) |
+| What this looks like in practice (reference examples) | 436 | Sarah's complete CLAUDE.md files at every level with annotations | [Link](https://hannahstulberg.substack.com/i/187471997/what-this-looks-like-in-practice-reference-examples) |
+| Level 0: ~/ CLAUDE.md (Sarah's preferences) | 442 | Personal working style; portable across jobs | [Link](https://hannahstulberg.substack.com/i/187471997/what-this-looks-like-in-practice-reference-examples) |
+| Level 1: ~/Acme/ CLAUDE.md (Company context) | 446 | Company, role, team, folder structure, connected tools | [Link](https://hannahstulberg.substack.com/i/187471997/what-this-looks-like-in-practice-reference-examples) |
+| Level 2: ~/Acme/Marketing/ CLAUDE.md (Area context) | 450 | Brand voice, target audience, team, document index, workflows | [Link](https://hannahstulberg.substack.com/i/187471997/what-this-looks-like-in-practice-reference-examples) |
+| Level 3: ~/Acme/Marketing/Q1 Campaign/ CLAUDE.md (Project context) | 454 | Messaging, product context, campaign team; most specific level | [Link](https://hannahstulberg.substack.com/i/187471997/what-this-looks-like-in-practice-reference-examples) |
+| Putting it all together | 460 | How intra-session and inter-session context management work as a cycle | [Link](https://hannahstulberg.substack.com/i/187471997/putting-it-all-together) |
+| What you should have now | 478 | Summary of outcomes from the article | [Link](https://hannahstulberg.substack.com/i/187471997/what-you-should-have-now) |
+| Your first hour | 494 | Step-by-step first-hour plan: pick area, create top-level file, create project file, use it | [Link](https://hannahstulberg.substack.com/i/187471997/your-first-hour) |
+| Want to go deeper? | 514 | Link to Claude Code Masterclass for developer-focused CLAUDE.md coverage | [Link](https://hannahstulberg.substack.com/i/187471997/want-to-go-deeper) |

--- a/claude-code-for-everything/06-the-one-file-that-can-save-your-team-thousands-of-hours/CLAUDE.md
+++ b/claude-code-for-everything/06-the-one-file-that-can-save-your-team-thousands-of-hours/CLAUDE.md
@@ -4,17 +4,17 @@
 
 ## Article Map
 
-| Section | Line | Coverage |
-|---------|------|----------|
-| Title & Subtitle | 26 | How shared context files turn individual AI use into team intelligence |
-| Introduction | 34 | The cost of re-explaining context: 6,000+ hours/year for a 100-person team |
-| Guest intro (Hannah Stulberg) | 36 | Hannah's background, In the Weeds newsletter, Claude Code for Everything series |
-| Shared AI Context: How One Change Saves Teams Thousands of Hours | 40 | The problem: individual AI use, 5 min/session context re-explaining, math on wasted hours |
-| The Solution: Shared Context Files | 64 | CLAUDE.md and AGENTS.md as onboarding docs for AI; auto-loaded instruction files; folder-based stacking |
-| Why Sharing Context Makes Your Whole Team Better | 78 | Knowledge compounding; one person's correction benefits everyone; Anthropic's own team practice |
-| How to Set It Up for Your Company | 94 | Three requirements: shared workspace, folder structure, contributing habit |
-| 1. A shared place to work | 106 | Cloud storage vs Git; approval workflows for changes |
-| 2. A folder structure that mirrors your company | 116 | Departments, teams, projects; context loads automatically per level |
-| 3. A habit of contributing | 124 | Ongoing updates; approval processes; compounding effect |
-| Start Small | 130 | Begin with one team; iterate; compounding benefit spreads naturally |
-| Want to go deeper? | 138 | Links to all five prior articles in the Claude Code for Everything series |
+| Section | Line | Coverage | Substack |
+|---------|------|----------|----------|
+| Title & Subtitle | 26 | How shared context files turn individual AI use into team intelligence | [Link](https://leadershipinchange.com/p/shared-ai-context-the-one-file-that-saves-your-team-thousands-of-hours) |
+| Introduction | 34 | The cost of re-explaining context: 6,000+ hours/year for a 100-person team | [Link](https://leadershipinchange.com/i/188185057/shared-ai-context-how-one-change-saves-teams-thousands-of-hours) |
+| Guest intro (Hannah Stulberg) | 36 | Hannah's background, In the Weeds newsletter, Claude Code for Everything series | [Link](https://leadershipinchange.com/i/188185057/shared-ai-context-how-one-change-saves-teams-thousands-of-hours) |
+| Shared AI Context: How One Change Saves Teams Thousands of Hours | 40 | The problem: individual AI use, 5 min/session context re-explaining, math on wasted hours | [Link](https://leadershipinchange.com/i/188185057/shared-ai-context-how-one-change-saves-teams-thousands-of-hours) |
+| The Solution: Shared Context Files | 64 | CLAUDE.md and AGENTS.md as onboarding docs for AI; auto-loaded instruction files; folder-based stacking | [Link](https://leadershipinchange.com/i/188185057/the-solution-shared-context-files) |
+| Why Sharing Context Makes Your Whole Team Better | 78 | Knowledge compounding; one person's correction benefits everyone; Anthropic's own team practice | [Link](https://leadershipinchange.com/i/188185057/why-sharing-context-makes-your-whole-team-better) |
+| How to Set It Up for Your Company | 94 | Three requirements: shared workspace, folder structure, contributing habit | [Link](https://leadershipinchange.com/i/188185057/how-to-set-it-up-for-your-company) |
+| 1. A shared place to work | 106 | Cloud storage vs Git; approval workflows for changes | [Link](https://leadershipinchange.com/i/188185057/how-to-set-it-up-for-your-company) |
+| 2. A folder structure that mirrors your company | 116 | Departments, teams, projects; context loads automatically per level | [Link](https://leadershipinchange.com/i/188185057/how-to-set-it-up-for-your-company) |
+| 3. A habit of contributing | 124 | Ongoing updates; approval processes; compounding effect | [Link](https://leadershipinchange.com/i/188185057/how-to-set-it-up-for-your-company) |
+| Start Small | 130 | Begin with one team; iterate; compounding benefit spreads naturally | [Link](https://leadershipinchange.com/i/188185057/start-small) |
+| Want to go deeper? | 138 | Links to all five prior articles in the Claude Code for Everything series | — |

--- a/claude-code-for-everything/07-your-status-line-is-empty-lets-fix-that/CLAUDE.md
+++ b/claude-code-for-everything/07-your-status-line-is-empty-lets-fix-that/CLAUDE.md
@@ -4,26 +4,26 @@
 
 ## Article Map
 
-| Section | Line | Coverage |
-|---------|------|----------|
-| Title & Subtitle | 18 | Turn the terminal into a command center |
-| By the end of this article, you'll have | 38 | A status line showing model, context, git branch, emails, meetings, weather, scores |
-| Meet the status line | 42 | What the status line is; CLI-only feature; status line 101 overview |
-| Every check breaks your flow | 50 | Why glanceable info prevents interruptions; replaces tab-switching |
-| What you can put on your status line | 58 | Full menu: basics (folder, model, context, cost), git info, external data |
-| Where the data comes from | 97 | Three data sources: web, CLI tools, APIs/MCPs |
-| Build your status line | 112 | Two-part build: core dashboard + external data; platform differences (Mac/Linux vs Windows) |
-| Part 1: Your core dashboard | 139 | Core status line elements |
-| Folder and model | 141 | Basic setup prompt; labels, icons (emoji vs Unicode) |
-| Make it look good | 176 | Plain text with pipes vs Powerline style; Nerd Fonts; color customization |
-| The one I'd call essential | 201 | Context progress bar: green/yellow/red thresholds; customization options |
-| Track your spend or usage | 224 | API billing (session cost) vs Max/Pro plan (5h and 7d usage limits); OAuth endpoint |
-| Part 2: Pull in everything else | 256 | External data sources; caching and conditional display |
-| The easiest wins: data from the web | 270 | Weather, air quality, sunrise/sunset, timezone, countdown, transit, stocks, sports, moon phase |
-| Data from your tools and services | 336 | Integrations requiring installed tools or connected accounts |
-| Git and GitHub | 340 | Current branch, uncommitted files, open PR count |
-| Connect your Google account (one-time setup) | 354 | Full 8-step Google Workspace MCP setup walkthrough with screenshots |
-| See your unread emails | 462 | Gmail count on status line after Google Workspace connection |
-| See your next meeting | 472 | Google Calendar next event with countdown |
-| The world (status line) is your oyster | 482 | Open-ended possibilities: Linear, Slack, deployment status, etc. |
-| What you should have now | 494 | Summary: oriented, focused, in flow; iterate as workflow evolves |
+| Section | Line | Coverage | Substack |
+|---------|------|----------|----------|
+| Title & Subtitle | 18 | Turn the terminal into a command center | [Link](https://hannahstulberg.substack.com/p/claude-code-for-everything-your-status-line-is-empty) |
+| By the end of this article, you'll have | 38 | A status line showing model, context, git branch, emails, meetings, weather, scores | [Link](https://hannahstulberg.substack.com/p/claude-code-for-everything-your-status-line-is-empty) |
+| Meet the status line | 42 | What the status line is; CLI-only feature; status line 101 overview | [Link](https://hannahstulberg.substack.com/i/190801933/meet-the-status-line) |
+| Every check breaks your flow | 50 | Why glanceable info prevents interruptions; replaces tab-switching | [Link](https://hannahstulberg.substack.com/i/190801933/every-check-breaks-your-flow) |
+| What you can put on your status line | 58 | Full menu: basics (folder, model, context, cost), git info, external data | [Link](https://hannahstulberg.substack.com/i/190801933/what-you-can-put-on-your-status-line) |
+| Where the data comes from | 97 | Three data sources: web, CLI tools, APIs/MCPs | [Link](https://hannahstulberg.substack.com/i/190801933/where-the-data-comes-from) |
+| Build your status line | 112 | Two-part build: core dashboard + external data; platform differences (Mac/Linux vs Windows) | [Link](https://hannahstulberg.substack.com/i/190801933/build-your-status-line) |
+| Part 1: Your core dashboard | 139 | Core status line elements | [Link](https://hannahstulberg.substack.com/i/190801933/part-1-your-core-dashboard) |
+| Folder and model | 141 | Basic setup prompt; labels, icons (emoji vs Unicode) | [Link](https://hannahstulberg.substack.com/i/190801933/folder-and-model) |
+| Make it look good | 176 | Plain text with pipes vs Powerline style; Nerd Fonts; color customization | [Link](https://hannahstulberg.substack.com/i/190801933/make-it-look-good) |
+| The one I'd call essential | 201 | Context progress bar: green/yellow/red thresholds; customization options | [Link](https://hannahstulberg.substack.com/i/190801933/the-one-id-call-essential) |
+| Track your spend or usage | 224 | API billing (session cost) vs Max/Pro plan (5h and 7d usage limits); OAuth endpoint | [Link](https://hannahstulberg.substack.com/i/190801933/track-your-spend-or-usage) |
+| Part 2: Pull in everything else | 256 | External data sources; caching and conditional display | [Link](https://hannahstulberg.substack.com/i/190801933/part-2-pull-in-everything-else) |
+| The easiest wins: data from the web | 270 | Weather, air quality, sunrise/sunset, timezone, countdown, transit, stocks, sports, moon phase | [Link](https://hannahstulberg.substack.com/i/190801933/the-easiest-wins-data-from-the-web) |
+| Data from your tools and services | 336 | Integrations requiring installed tools or connected accounts | [Link](https://hannahstulberg.substack.com/i/190801933/data-from-your-tools-and-services) |
+| Git and GitHub | 340 | Current branch, uncommitted files, open PR count | [Link](https://hannahstulberg.substack.com/i/190801933/git-and-github) |
+| Connect your Google account (one-time setup) | 354 | Full 8-step Google Workspace MCP setup walkthrough with screenshots | [Link](https://hannahstulberg.substack.com/i/190801933/connect-your-google-account-one-time-setup) |
+| See your unread emails | 462 | Gmail count on status line after Google Workspace connection | [Link](https://hannahstulberg.substack.com/i/190801933/see-your-unread-emails) |
+| See your next meeting | 472 | Google Calendar next event with countdown | [Link](https://hannahstulberg.substack.com/i/190801933/see-your-next-meeting) |
+| The world (status line) is your oyster | 482 | Open-ended possibilities: Linear, Slack, deployment status, etc. | [Link](https://hannahstulberg.substack.com/i/190801933/the-world-status-line-is-your-oyster) |
+| What you should have now | 494 | Summary: oriented, focused, in flow; iterate as workflow evolves | [Link](https://hannahstulberg.substack.com/i/190801933/what-you-should-have-now) |

--- a/standalone/skip-the-terminal-and-8-other-claude-code-tricks-for-non-technical-users/CLAUDE.md
+++ b/standalone/skip-the-terminal-and-8-other-claude-code-tricks-for-non-technical-users/CLAUDE.md
@@ -4,17 +4,17 @@
 
 ## Article Map
 
-| Section | Line | Coverage |
-|---------|------|----------|
-| Title & Subtitle | 16 | Tips and tricks after 350+ hours of use |
-| Introduction | 20 | Precursor to Claude Code for Everything series; the context problem with AI tools |
-| 1. The terminal is a black box - stop using it | 48 | Use an IDE instead of standalone terminal; see files, preview docs, review changes, access config |
-| 2. Using Cursor as your IDE lets you pick the best model for the job | 66 | Cursor's multi-model chat feature; not locked into one model |
-| 3. Make sure you can see hidden files | 74 | .claude/ folder contains skills, commands, agents, CLAUDE.md; visibility in different IDEs |
-| 4. Drag and drop files into the terminal | 95 | Share images and documents with Claude by dragging into command line |
-| 5. Run tasks in parallel to move faster | 101 | Multiple terminal instances for separate Claude Code sessions; focused context per task |
-| 6. Split your terminals so you know when tasks finish | 113 | Monitor 2-3 sessions simultaneously; reduce cognitive load of tab switching |
-| 7. Context limits will bite you - watch the status line | 121 | Status line shows model, directory, context usage, cost; manual compact at 50-60% |
-| 8. Stop typing - talk instead | 136 | Wispr Flow for dictation; voice removes friction |
-| 9. Every session is a chance to teach Claude something | 144 | Build CLAUDE.md, commands, skills, agents; compound 1% improvements daily |
-| The bottom line | 152 | Worth the learning curve; these tricks transformed the experience |
+| Section | Line | Coverage | Substack |
+|---------|------|----------|----------|
+| Title & Subtitle | 16 | Tips and tricks after 350+ hours of use | [Link](https://hannahstulberg.substack.com/p/skip-the-terminal-and-8-other-claude) |
+| Introduction | 20 | Precursor to Claude Code for Everything series; the context problem with AI tools | [Link](https://hannahstulberg.substack.com/p/skip-the-terminal-and-8-other-claude) |
+| 1. The terminal is a black box - stop using it | 48 | Use an IDE instead of standalone terminal; see files, preview docs, review changes, access config | [Link](https://hannahstulberg.substack.com/i/183150134/1-the-terminal-is-a-black-box-stop-using-it) |
+| 2. Using Cursor as your IDE lets you pick the best model for the job | 66 | Cursor's multi-model chat feature; not locked into one model | [Link](https://hannahstulberg.substack.com/i/183150134/2-using-cursor-as-your-ide-lets-you-pick-the-best-model-for-the-job) |
+| 3. Make sure you can see hidden files | 74 | .claude/ folder contains skills, commands, agents, CLAUDE.md; visibility in different IDEs | [Link](https://hannahstulberg.substack.com/i/183150134/3-make-sure-you-can-see-hidden-files) |
+| 4. Drag and drop files into the terminal | 95 | Share images and documents with Claude by dragging into command line | [Link](https://hannahstulberg.substack.com/i/183150134/4-drag-and-drop-files-into-the-terminal-to-share-them-with-claude) |
+| 5. Run tasks in parallel to move faster | 101 | Multiple terminal instances for separate Claude Code sessions; focused context per task | [Link](https://hannahstulberg.substack.com/i/183150134/5-run-tasks-in-parallel-to-move-faster) |
+| 6. Split your terminals so you know when tasks finish | 113 | Monitor 2-3 sessions simultaneously; reduce cognitive load of tab switching | [Link](https://hannahstulberg.substack.com/i/183150134/6-split-your-terminals-so-you-know-when-tasks-finish) |
+| 7. Context limits will bite you - watch the status line | 121 | Status line shows model, directory, context usage, cost; manual compact at 50-60% | [Link](https://hannahstulberg.substack.com/i/183150134/7-context-limits-will-bite-you-watch-the-status-line) |
+| 8. Stop typing - talk instead | 136 | Wispr Flow for dictation; voice removes friction | [Link](https://hannahstulberg.substack.com/i/183150134/8-stop-typing-talk-instead) |
+| 9. Every session is a chance to teach Claude something | 144 | Build CLAUDE.md, commands, skills, agents; compound 1% improvements daily | [Link](https://hannahstulberg.substack.com/i/183150134/9-every-session-is-a-chance-to-teach-claude-something) |
+| The bottom line | 152 | Worth the learning curve; these tricks transformed the experience | [Link](https://hannahstulberg.substack.com/i/183150134/the-bottom-line) |

--- a/standalone/stop-typing-start-talking/CLAUDE.md
+++ b/standalone/stop-typing-start-talking/CLAUDE.md
@@ -4,15 +4,15 @@
 
 ## Article Map
 
-| Section | Line | Coverage |
-|---------|------|----------|
-| Title & Subtitle | 16 | Dictation + AI editing saves 10+ hours a week |
-| You already know what you want to say | 20 | The blank page problem; typing forces simultaneous writing and editing |
-| Let's run an experiment | 32 | Interactive typing test; average 40 WPM vs actual writing speed |
-| Your typing speed isn't your writing speed | 42 | Typing speed vs writing speed vs speaking speed (130-160 WPM); 3-4x faster speaking |
-| The workflow: dictation + AI editing | 54 | Three tiers: basic (any AI chat), intermediate (Wispr Flow), advanced (AI coding tools with saved skills) |
-| Basic: Dictate into any AI chat | 58 | Three-step flow: dictate raw thoughts, ask AI to clean up, review and send |
-| Intermediate: Better transcription with Wispr Flow | 68 | More accurate transcription; dictate into any app including non-voice-enabled ones |
-| Advanced: AI coding tools with saved skills | 77 | Claude Code, Cursor, Antigravity with reusable editing instructions |
-| Start simple, scale up | 85 | Longer content = more time saved; progression path from basic to advanced |
-| Your challenge: try dictation + AI editing once this week | 89 | New year challenge; push through initial discomfort; dictate first, let AI polish |
+| Section | Line | Coverage | Substack |
+|---------|------|----------|----------|
+| Title & Subtitle | 16 | Dictation + AI editing saves 10+ hours a week | [Link](https://hannahstulberg.substack.com/p/stop-typing-start-talking-how-dictation) |
+| You already know what you want to say | 20 | The blank page problem; typing forces simultaneous writing and editing | [Link](https://hannahstulberg.substack.com/p/stop-typing-start-talking-how-dictation) |
+| Let's run an experiment | 32 | Interactive typing test; average 40 WPM vs actual writing speed | [Link](https://hannahstulberg.substack.com/i/183508107/lets-run-an-experiment) |
+| Your typing speed isn't your writing speed | 42 | Typing speed vs writing speed vs speaking speed (130-160 WPM); 3-4x faster speaking | [Link](https://hannahstulberg.substack.com/i/183508107/your-typing-speed-isnt-your-writing-speed) |
+| The workflow: dictation + AI editing | 54 | Three tiers: basic (any AI chat), intermediate (Wispr Flow), advanced (AI coding tools with saved skills) | [Link](https://hannahstulberg.substack.com/i/183508107/the-workflow-dictation-ai-editing) |
+| Basic: Dictate into any AI chat | 58 | Three-step flow: dictate raw thoughts, ask AI to clean up, review and send | [Link](https://hannahstulberg.substack.com/i/183508107/basic-dictate-into-any-ai-chat) |
+| Intermediate: Better transcription with Wispr Flow | 68 | More accurate transcription; dictate into any app including non-voice-enabled ones | [Link](https://hannahstulberg.substack.com/i/183508107/intermediate-better-transcription-with-wispr-flow) |
+| Advanced: AI coding tools with saved skills | 77 | Claude Code, Cursor, Antigravity with reusable editing instructions | [Link](https://hannahstulberg.substack.com/i/183508107/advanced-ai-coding-tools-with-saved-editing-instructions) |
+| Start simple, scale up | 85 | Longer content = more time saved; progression path from basic to advanced | [Link](https://hannahstulberg.substack.com/i/183508107/start-simple-scale-up) |
+| Your challenge: try dictation + AI editing once this week | 89 | New year challenge; push through initial discomfort; dictate first, let AI polish | [Link](https://hannahstulberg.substack.com/i/183508107/your-challenge-try-dictation-ai-editing-once-this-week) |

--- a/tool-school/01-github-101/CLAUDE.md
+++ b/tool-school/01-github-101/CLAUDE.md
@@ -4,79 +4,79 @@
 
 ## Article Map
 
-| Section | Line | Coverage |
-|---------|------|----------|
-| Title & Subtitle | 24 | Everything you need to start using GitHub: setup, workflow, interactive lesson |
-| Introduction | 28 | Hannah's personal story of GitHub mistakes; teaming up with Sidwyn Koh |
-| By the end of this article, you'll have | 54 | Learning objectives: concepts, setup, practice repo, daily workflow, collaboration, troubleshooting |
-| Here's how this guide is organized | 69 | Table of contents for the guide's seven major sections |
-| GitHub in Plain Language | 90 | What GitHub is, why it matters, how collaboration works |
-| GitHub isn't just for engineers | 94 | GitHub as collaboration platform for any knowledge work; version history, review, rollback |
-| Why GitHub matters even more now | 113 | AI-native teams need shared context, skills, commands; review for AI-generated changes |
-| How collaboration actually works | 127 | Sarah and Jake walkthrough: clone, branch, commit, push, PR, review, merge |
-| Meet the Practice Repo | 156 | Introduction to sidwyn/acme-ops; fork vs clone; article included as markdown in repo |
-| Part 1: Setup & Installation | 183 | Five things to install before collaborating |
-| 1. Create a GitHub Account | 204 | github.com/signup |
-| 2. Install Git | 208 | Claude Code way and manual way (Mac/Windows) |
-| 3. Configure Git | 226 | Set name and email for commit attribution |
-| 4. Set Up SSH Keys | 238 | SSH key pairs explained; generation and GitHub registration |
-| 5. Install the GitHub CLI | 260 | gh CLI for terminal-based GitHub management |
-| 6. Install the GitHub MCP (optional) | 272 | MCP plugin for direct Claude Code-GitHub integration |
-| You're set up | 284 | Summary of installed toolchain |
-| Part 2: GitHub Repositories 101 | 296 | Where work lives and how to organize it |
-| What is a Repository? | 307 | Project folder with version history; scope and isolation |
-| What a Repo Looks Like on GitHub | 319 | File list, README, commit history |
-| How to Organize Your Repos | 331 | One repo per project/domain; team repos vs personal repo |
-| Before You Create: Key Decisions | 353 | Three decisions GitHub asks when creating a repo |
-| Public vs. Private | 357 | Default to private; when to go public |
-| Public repos need a license | 371 | MIT license recommendation; license chooser |
-| Initialize with a README | 381 | Always check the box |
-| GitHub vs. Cloud Storage | 385 | When to use each; moving existing folders to GitHub |
-| Finding and Using Other People's Repos | 417 | Searching, cloning, forking other projects |
-| Finding repos | 423 | GitHub search; awesome-claude-code curated list |
-| Cloning repos | 429 | Download a copy; read the README |
-| Forking repos | 445 | Your own modifiable copy on GitHub |
-| Your First Repo: Fork and Clone acme-ops | 451 | Hands-on fork and clone of the practice repo |
-| Step 1: Fork the repo on GitHub | 457 | One-click fork |
-| Step 2: Clone your fork to your machine | 461 | Where to keep repos; don't nest repos; Claude Code and manual way |
-| You're Ready to Work | 491 | IDE, terminal, and GitHub web interface orientation |
-| Part 3: The Daily GitHub Workflow | 503 | Everything needed to start working daily |
-| GitHub Is the New Google Drive | 514 | Six core concepts mapped to Google Drive equivalents |
-| The Short Version | 522 | Complete six-step workflow: branch, edit, commit, push, PR, merge |
-| The Deep Dive | 555 | Each step explained in full with what's happening under the hood |
-| Step 1: Get to your branch | 561 | Branches explained; creating, naming; when to branch vs work on main |
-| Pulling | 587 | Two pulling scenarios: your branch and main into your branch |
-| Pulling your branch | 595 | Keep local copy in sync with GitHub |
-| Pulling main into your branch | 605 | Merge vs rebase; when to use each |
-| Stashing | 623 | Pause uncommitted work to switch branches safely |
-| Step 2: Make your edits | 647 | Just edit normally; Git tracks in background |
-| Step 3: Commit | 653 | Review changes, save snapshot; commit messages; commit early and often |
-| Step 4: Push | 701 | Upload commits to GitHub |
-| Step 5: Open a pull request (PR) | 713 | Creating PRs; push vs PR distinction |
-| Creating a pull request | 721 | Claude Code and manual way; PR title and description |
-| Adding reviewers to your PR | 740 | How to choose and add reviewers |
-| Reviewing a pull request | 757 | Three parts: diff, comments, close review |
-| Looking at the diff | 769 | Browser and Claude Code approaches |
-| Leaving comments | 779 | Line-level and general feedback |
-| Closing out your review | 787 | Comment, approve, or request changes |
-| How to know when your PR is approved | 803 | Email, GitHub bell, Slack, PR page status |
-| Step 6: Merge | 826 | Combine changes into main |
-| Merge conflicts | 830 | What they are; Claude Code resolution; manual markers |
-| Merging a pull request | 850 | Three merge options: squash, merge commit, rebase; branch cleanup |
-| Beyond the Daily Workflow | 874 | Additional GitHub features |
-| Notifications | 876 | Email, bell, Slack, mobile; customization |
-| Putting It All Together: Sarah's Full Workflow | 895 | Complete end-to-end example with all nine steps |
-| When Things Go Wrong | 923 | Four common Git errors and fixes |
-| "Your branch is behind 'origin/main'" | 929 | Local copy out of date; git pull |
-| "Merge conflict in [filename]" | 939 | Two people changed same lines; resolution |
-| "HEAD detached at [some hash]" | 949 | Checked out a commit instead of branch |
-| "Permission denied (publickey)" | 959 | SSH key not set up correctly |
-| "I accidentally cloned a repo inside another repo" | 969 | Nested repos; move to fix |
-| The Big Reassurance | 975 | Git is recoverable; errors look scarier than they are |
-| .gitignore: What NOT to Upload | 981 | API keys, node_modules, .env security; templates |
-| What You Should Have Now | 997 | Summary of all outcomes |
-| Your Turn: Submit Your First PR | 1009 | Interactive exercise: easy path and challenge path |
-| The easy path | 1026 | Create takeaways file, commit, push, open PR |
-| The challenge path | 1032 | Edit community-board.md, resolve merge conflict |
-| Preview: GitHub 102 | 1038 | Upcoming topics: worktrees, Actions, Issues, Pages |
-| Want to Go Deeper? | 1051 | External resources: Learn Git Branching, GitHub skills, Pro Git, Oh Shit Git |
+| Section | Line | Coverage | Substack |
+|---------|------|----------|----------|
+| Title & Subtitle | 24 | Everything you need to start using GitHub: setup, workflow, interactive lesson | [Link](https://hannahstulberg.substack.com/p/tool-school-github-101) |
+| Introduction | 28 | Hannah's personal story of GitHub mistakes; teaming up with Sidwyn Koh | [Link](https://hannahstulberg.substack.com/p/tool-school-github-101) |
+| By the end of this article, you'll have | 54 | Learning objectives: concepts, setup, practice repo, daily workflow, collaboration, troubleshooting | [Link](https://hannahstulberg.substack.com/p/tool-school-github-101) |
+| Here's how this guide is organized | 69 | Table of contents for the guide's seven major sections | [Link](https://hannahstulberg.substack.com/p/tool-school-github-101) |
+| GitHub in Plain Language | 90 | What GitHub is, why it matters, how collaboration works | [Link](https://hannahstulberg.substack.com/i/189320562/github-in-plain-language) |
+| GitHub isn't just for engineers | 94 | GitHub as collaboration platform for any knowledge work; version history, review, rollback | [Link](https://hannahstulberg.substack.com/i/189320562/github-in-plain-language) |
+| Why GitHub matters even more now | 113 | AI-native teams need shared context, skills, commands; review for AI-generated changes | [Link](https://hannahstulberg.substack.com/i/189320562/github-in-plain-language) |
+| How collaboration actually works | 127 | Sarah and Jake walkthrough: clone, branch, commit, push, PR, review, merge | [Link](https://hannahstulberg.substack.com/i/189320562/github-in-plain-language) |
+| Meet the Practice Repo | 156 | Introduction to sidwyn/acme-ops; fork vs clone; article included as markdown in repo | [Link](https://hannahstulberg.substack.com/i/189320562/meet-the-practice-repo) |
+| Part 1: Setup & Installation | 183 | Five things to install before collaborating | [Link](https://hannahstulberg.substack.com/i/189320562/part-1-setup-and-installation) |
+| 1. Create a GitHub Account | 204 | github.com/signup | [Link](https://hannahstulberg.substack.com/i/189320562/part-1-setup-and-installation) |
+| 2. Install Git | 208 | Claude Code way and manual way (Mac/Windows) | [Link](https://hannahstulberg.substack.com/i/189320562/part-1-setup-and-installation) |
+| 3. Configure Git | 226 | Set name and email for commit attribution | [Link](https://hannahstulberg.substack.com/i/189320562/part-1-setup-and-installation) |
+| 4. Set Up SSH Keys | 238 | SSH key pairs explained; generation and GitHub registration | [Link](https://hannahstulberg.substack.com/i/189320562/part-1-setup-and-installation) |
+| 5. Install the GitHub CLI | 260 | gh CLI for terminal-based GitHub management | [Link](https://hannahstulberg.substack.com/i/189320562/part-1-setup-and-installation) |
+| 6. Install the GitHub MCP (optional) | 272 | MCP plugin for direct Claude Code-GitHub integration | [Link](https://hannahstulberg.substack.com/i/189320562/part-1-setup-and-installation) |
+| You're set up | 284 | Summary of installed toolchain | [Link](https://hannahstulberg.substack.com/i/189320562/part-1-setup-and-installation) |
+| Part 2: GitHub Repositories 101 | 296 | Where work lives and how to organize it | [Link](https://hannahstulberg.substack.com/i/189320562/part-2-github-repositories-101) |
+| What is a Repository? | 307 | Project folder with version history; scope and isolation | [Link](https://hannahstulberg.substack.com/i/189320562/part-2-github-repositories-101) |
+| What a Repo Looks Like on GitHub | 319 | File list, README, commit history | [Link](https://hannahstulberg.substack.com/i/189320562/part-2-github-repositories-101) |
+| How to Organize Your Repos | 331 | One repo per project/domain; team repos vs personal repo | [Link](https://hannahstulberg.substack.com/i/189320562/part-2-github-repositories-101) |
+| Before You Create: Key Decisions | 353 | Three decisions GitHub asks when creating a repo | [Link](https://hannahstulberg.substack.com/i/189320562/part-2-github-repositories-101) |
+| Public vs. Private | 357 | Default to private; when to go public | [Link](https://hannahstulberg.substack.com/i/189320562/part-2-github-repositories-101) |
+| Public repos need a license | 371 | MIT license recommendation; license chooser | [Link](https://hannahstulberg.substack.com/i/189320562/part-2-github-repositories-101) |
+| Initialize with a README | 381 | Always check the box | [Link](https://hannahstulberg.substack.com/i/189320562/part-2-github-repositories-101) |
+| GitHub vs. Cloud Storage | 385 | When to use each; moving existing folders to GitHub | [Link](https://hannahstulberg.substack.com/i/189320562/part-2-github-repositories-101) |
+| Finding and Using Other People's Repos | 417 | Searching, cloning, forking other projects | [Link](https://hannahstulberg.substack.com/i/189320562/part-2-github-repositories-101) |
+| Finding repos | 423 | GitHub search; awesome-claude-code curated list | [Link](https://hannahstulberg.substack.com/i/189320562/part-2-github-repositories-101) |
+| Cloning repos | 429 | Download a copy; read the README | [Link](https://hannahstulberg.substack.com/i/189320562/part-2-github-repositories-101) |
+| Forking repos | 445 | Your own modifiable copy on GitHub | [Link](https://hannahstulberg.substack.com/i/189320562/part-2-github-repositories-101) |
+| Your First Repo: Fork and Clone acme-ops | 451 | Hands-on fork and clone of the practice repo | [Link](https://hannahstulberg.substack.com/i/189320562/part-2-github-repositories-101) |
+| Step 1: Fork the repo on GitHub | 457 | One-click fork | [Link](https://hannahstulberg.substack.com/i/189320562/part-2-github-repositories-101) |
+| Step 2: Clone your fork to your machine | 461 | Where to keep repos; don't nest repos; Claude Code and manual way | [Link](https://hannahstulberg.substack.com/i/189320562/part-2-github-repositories-101) |
+| You're Ready to Work | 491 | IDE, terminal, and GitHub web interface orientation | [Link](https://hannahstulberg.substack.com/i/189320562/youre-ready-to-work) |
+| Part 3: The Daily GitHub Workflow | 503 | Everything needed to start working daily | [Link](https://hannahstulberg.substack.com/i/189320562/part-3-the-daily-github-workflow) |
+| GitHub Is the New Google Drive | 514 | Six core concepts mapped to Google Drive equivalents | [Link](https://hannahstulberg.substack.com/i/189320562/part-3-the-daily-github-workflow) |
+| The Short Version | 522 | Complete six-step workflow: branch, edit, commit, push, PR, merge | [Link](https://hannahstulberg.substack.com/i/189320562/part-3-the-daily-github-workflow) |
+| The Deep Dive | 555 | Each step explained in full with what's happening under the hood | [Link](https://hannahstulberg.substack.com/i/189320562/part-3-the-daily-github-workflow) |
+| Step 1: Get to your branch | 561 | Branches explained; creating, naming; when to branch vs work on main | [Link](https://hannahstulberg.substack.com/i/189320562/part-3-the-daily-github-workflow) |
+| Pulling | 587 | Two pulling scenarios: your branch and main into your branch | [Link](https://hannahstulberg.substack.com/i/189320562/part-3-the-daily-github-workflow) |
+| Pulling your branch | 595 | Keep local copy in sync with GitHub | [Link](https://hannahstulberg.substack.com/i/189320562/part-3-the-daily-github-workflow) |
+| Pulling main into your branch | 605 | Merge vs rebase; when to use each | [Link](https://hannahstulberg.substack.com/i/189320562/part-3-the-daily-github-workflow) |
+| Stashing | 623 | Pause uncommitted work to switch branches safely | [Link](https://hannahstulberg.substack.com/i/189320562/part-3-the-daily-github-workflow) |
+| Step 2: Make your edits | 647 | Just edit normally; Git tracks in background | [Link](https://hannahstulberg.substack.com/i/189320562/part-3-the-daily-github-workflow) |
+| Step 3: Commit | 653 | Review changes, save snapshot; commit messages; commit early and often | [Link](https://hannahstulberg.substack.com/i/189320562/part-3-the-daily-github-workflow) |
+| Step 4: Push | 701 | Upload commits to GitHub | [Link](https://hannahstulberg.substack.com/i/189320562/part-3-the-daily-github-workflow) |
+| Step 5: Open a pull request (PR) | 713 | Creating PRs; push vs PR distinction | [Link](https://hannahstulberg.substack.com/i/189320562/part-3-the-daily-github-workflow) |
+| Creating a pull request | 721 | Claude Code and manual way; PR title and description | [Link](https://hannahstulberg.substack.com/i/189320562/part-3-the-daily-github-workflow) |
+| Adding reviewers to your PR | 740 | How to choose and add reviewers | [Link](https://hannahstulberg.substack.com/i/189320562/part-3-the-daily-github-workflow) |
+| Reviewing a pull request | 757 | Three parts: diff, comments, close review | [Link](https://hannahstulberg.substack.com/i/189320562/part-3-the-daily-github-workflow) |
+| Looking at the diff | 769 | Browser and Claude Code approaches | [Link](https://hannahstulberg.substack.com/i/189320562/part-3-the-daily-github-workflow) |
+| Leaving comments | 779 | Line-level and general feedback | [Link](https://hannahstulberg.substack.com/i/189320562/part-3-the-daily-github-workflow) |
+| Closing out your review | 787 | Comment, approve, or request changes | [Link](https://hannahstulberg.substack.com/i/189320562/part-3-the-daily-github-workflow) |
+| How to know when your PR is approved | 803 | Email, GitHub bell, Slack, PR page status | [Link](https://hannahstulberg.substack.com/i/189320562/part-3-the-daily-github-workflow) |
+| Step 6: Merge | 826 | Combine changes into main | [Link](https://hannahstulberg.substack.com/i/189320562/part-3-the-daily-github-workflow) |
+| Merge conflicts | 830 | What they are; Claude Code resolution; manual markers | [Link](https://hannahstulberg.substack.com/i/189320562/part-3-the-daily-github-workflow) |
+| Merging a pull request | 850 | Three merge options: squash, merge commit, rebase; branch cleanup | [Link](https://hannahstulberg.substack.com/i/189320562/part-3-the-daily-github-workflow) |
+| Beyond the Daily Workflow | 874 | Additional GitHub features | — |
+| Notifications | 876 | Email, bell, Slack, mobile; customization | — |
+| Putting It All Together: Sarah's Full Workflow | 895 | Complete end-to-end example with all nine steps | — |
+| When Things Go Wrong | 923 | Four common Git errors and fixes | [Link](https://hannahstulberg.substack.com/i/189320562/when-things-go-wrong) |
+| "Your branch is behind 'origin/main'" | 929 | Local copy out of date; git pull | [Link](https://hannahstulberg.substack.com/i/189320562/when-things-go-wrong) |
+| "Merge conflict in [filename]" | 939 | Two people changed same lines; resolution | [Link](https://hannahstulberg.substack.com/i/189320562/when-things-go-wrong) |
+| "HEAD detached at [some hash]" | 949 | Checked out a commit instead of branch | [Link](https://hannahstulberg.substack.com/i/189320562/when-things-go-wrong) |
+| "Permission denied (publickey)" | 959 | SSH key not set up correctly | [Link](https://hannahstulberg.substack.com/i/189320562/when-things-go-wrong) |
+| "I accidentally cloned a repo inside another repo" | 969 | Nested repos; move to fix | [Link](https://hannahstulberg.substack.com/i/189320562/when-things-go-wrong) |
+| The Big Reassurance | 975 | Git is recoverable; errors look scarier than they are | [Link](https://hannahstulberg.substack.com/i/189320562/when-things-go-wrong) |
+| .gitignore: What NOT to Upload | 981 | API keys, node_modules, .env security; templates | [Link](https://hannahstulberg.substack.com/i/189320562/gitignore-what-not-to-upload-for-coding-projects) |
+| What You Should Have Now | 997 | Summary of all outcomes | [Link](https://hannahstulberg.substack.com/i/189320562/what-you-should-have-now) |
+| Your Turn: Submit Your First PR | 1009 | Interactive exercise: easy path and challenge path | [Link](https://hannahstulberg.substack.com/i/189320562/your-turn-submit-your-first-pr) |
+| The easy path | 1026 | Create takeaways file, commit, push, open PR | [Link](https://hannahstulberg.substack.com/i/189320562/your-turn-submit-your-first-pr) |
+| The challenge path | 1032 | Edit community-board.md, resolve merge conflict | [Link](https://hannahstulberg.substack.com/i/189320562/your-turn-submit-your-first-pr) |
+| Preview: GitHub 102 | 1038 | Upcoming topics: worktrees, Actions, Issues, Pages | [Link](https://hannahstulberg.substack.com/i/189320562/preview-github-102) |
+| Want to Go Deeper? | 1051 | External resources: Learn Git Branching, GitHub skills, Pro Git, Oh Shit Git | [Link](https://hannahstulberg.substack.com/i/189320562/want-to-go-deeper) |

--- a/tool-school/02-benchmarking-101/CLAUDE.md
+++ b/tool-school/02-benchmarking-101/CLAUDE.md
@@ -2,49 +2,59 @@
 
 **Author(s):** Hannah Stulberg, Akshat Khandelwal | **Published:** 2026-03-31 | **Series:** Tool School #2
 
+## Companion data: model releases
+
+This article has a `releases/` subfolder with structured data for individual model launches that the Benchmarking 101 framework can be applied to. Each release is a folder containing extracted scorecard data, source chart images, and pricing — curated by Hannah from the announcement page (since vendor scorecards are typically image-based and unreadable by WebFetch).
+
+The `explain-ai-model-release` skill reads from this folder before falling back to web fetching. To add a new release, create `releases/YYYY-MM-MODEL-SLUG/release.md` following the schema established by existing entries.
+
+| Release | Folder |
+|---|---|
+| Claude Opus 4.7 (2026-04-16) | `releases/2026-04-opus-4-7/` |
+
 ## Article Map
 
-| Section | Line | Coverage |
-|---------|------|----------|
-| Title & Subtitle | 23 | How to read AI model report cards - learn to read the scorecard behind every AI model launch |
-| Series Introduction | 26 | Tool School series context, link to GitHub 101 |
-| Opening & Motivation | 31 | Why benchmark literacy matters - 40 models in 14 months, scorecards you can't read |
-| Co-author Introduction | 39 | Akshat Khandelwal (PM at DoorDash, Help Me Unpack Substack) |
-| Learning Outcomes | 47 | 5 things you'll have by the end: benchmark understanding, major benchmarks, scorecard reading, cost awareness, confidence |
-| Guide Organization | 55 | 5-section roadmap of the article |
-| The Short Version | 63 | 2-minute framework: 4 benchmark categories, 3 questions to ask, relevance tiers, 4 things to watch |
-| The Pace of Change: 40 Models in 14 Months | 99 | Full timeline of model launches Jan 2025 - Mar 2026 across Anthropic, OpenAI, Google |
-| Every Launch Changes What You Can Build | 125 | Why the accelerating pace matters for your work - build for the model coming in 6 months |
-| Benchmarks 101 | 137 | What benchmarks actually measure, how models are scored, terms you need to know |
-| A High SAT Score Doesn't Make Someone a Great Colleague | 141 | SAT metaphor - benchmark scores are standardized tests for AI, each measures one narrow skill |
-| What a Benchmark Actually Is | 155 | Definition: standardized test for AI models - fixed questions, tasks with answers, or head-to-head |
-| Benchmarks Use One of 3 Grading Systems | 161 | Pass@1 (one attempt), Pass@k (multiple attempts), Elo rating (head-to-head via Chatbot Arena) |
-| There Are 4 Major Categories of Benchmarks | 177 | Knowledge & Reasoning, Coding, Reasoning, Agentic & Computer Use |
-| Why Only a Handful of Benchmarks Become Standard | 193 | 3 bars: hard enough, simple enough metric, interpretable to non-researchers |
-| The Benchmark Reference Table | 203 | Complete table of every major benchmark: category, year, creator, what it tests, scoring |
-| The Major Benchmarks | 226 | Deep dive on each benchmark with example cards |
-| Knowledge & Reasoning Benchmarks | 228 | MMLU (2020), GPQA Diamond (2023), HLE (2025), GDPval (2025) |
-| Coding Benchmarks | 256 | SWE-bench Verified (2024), SWE-bench Pro (2025), SWE-Lancer (2025), plus the real-world gap |
-| Reasoning Benchmarks | 284 | ARC-AGI-3 (2026) and ARC-AGI-2 (2025) - novel problem-solving the model has never seen |
-| Agentic & Computer Use Benchmarks | 300 | OSWorld, tau2-bench, BigLaw Bench, Terminal-Bench 2.0 - sustained professional work |
-| Why Benchmarks Expire | 326 | When everyone gets an A, the A stops meaning anything - saturation, contamination, optimization |
-| Models Improve Faster Than New Tests | 338 | Saturation: scores converge, spread disappears, test becomes noise |
-| Training Data Gets Contaminated | 344 | Contamination: models see test answers in training data - SWE-bench Verified example |
-| Optimization Pressure (Goodhart's Law) | 354 | When a measure becomes a target, it ceases to be a good measure |
-| The Cycle Compounds and Accelerates | 358 | ImageNet lasted 5 years, MMLU 3, SWE-bench Verified 2 - ARC-AGI-3's radical response |
-| Which Benchmarks Are Still Working Right Now? | 374 | 3 questions: How long public? Who created it? Scores still spread out? |
-| Where Each Benchmark Stands Right Now | 384 | Trust tiers: High (ARC-AGI-3, ARC-AGI-2, HLE, SWE-bench Pro, OSWorld, Terminal-Bench 2.0), Moderate, Low |
-| Where to Check Scores Yourself | 421 | 5 independent sources: Chatbot Arena, Artificial Analysis, ARC Prize, Scale AI, Stanford CRFM |
-| Apply What You've Learned: Read the Scorecard | 433 | Real benchmark table from Anthropic's Opus 4.6 launch - read and evaluate every line |
-| You Recognize Every Name on This Table | 452 | Applying benchmark knowledge to identify each test in the Opus 4.6 scorecard |
-| You Know What the Scores Actually Mean | 456 | Understanding pass@1 vs Elo rating in context |
-| You Can Evaluate How Relevant Every Score Is | 462 | Relevance assessment of each Opus 4.6 benchmark score with reasoning |
-| How to Read the Next Model Launch | 479 | Head-to-head comparison and what to watch for in any announcement |
-| No Single Model Wins | 483 | Side-by-side comparison: Opus 4.6 vs Sonnet 4.6 vs GPT-5.4 vs Gemini 3.1 Pro |
-| 4 Things to Watch for in Any Launch Announcement | 495 | Missing benchmarks, baseline comparisons, human preference vs benchmarks, methodology transparency |
-| What the Scorecard Leaves Out: Cost | 523 | API pricing, tokens, input/output costs - the dimension most tables omit |
-| Same Scores, Wildly Different Prices | 539 | Output token pricing comparison across models, DeepSeek R1 cost advantage |
-| Cost-Adjusted Evaluation Is Coming | 551 | ARC-AGI-2 measures cost-per-task, Artificial Analysis price-performance rankings |
-| Reading Recent Model Launches | 559 | Informed reads of Opus 4.6, Sonnet 4.6, and GPT-5.4 launches |
-| Best for What? At What Price? On Which Tests? | 581 | Summary: no single model wins across the board |
-| You Can Read the Next Model Announcement Yourself | 587 | Closing recap of 5 learning outcomes and confidence statement |
+| Section | Line | Coverage | Substack |
+|---------|------|----------|----------|
+| Title & Subtitle | 23 | How to read AI model report cards - learn to read the scorecard behind every AI model launch | [Link](https://hannahstulberg.substack.com/p/tool-school-benchmarking-101-how-to-read-ai-model-report-cards) |
+| Series Introduction | 26 | Tool School series context, link to GitHub 101 | [Link](https://hannahstulberg.substack.com/p/tool-school-benchmarking-101-how-to-read-ai-model-report-cards) |
+| Opening & Motivation | 31 | Why benchmark literacy matters - 40 models in 14 months, scorecards you can't read | [Link](https://hannahstulberg.substack.com/p/tool-school-benchmarking-101-how-to-read-ai-model-report-cards) |
+| Co-author Introduction | 39 | Akshat Khandelwal (PM at DoorDash, Help Me Unpack Substack) | [Link](https://hannahstulberg.substack.com/p/tool-school-benchmarking-101-how-to-read-ai-model-report-cards) |
+| Learning Outcomes | 47 | 5 things you'll have by the end: benchmark understanding, major benchmarks, scorecard reading, cost awareness, confidence | [Link](https://hannahstulberg.substack.com/p/tool-school-benchmarking-101-how-to-read-ai-model-report-cards) |
+| Guide Organization | 55 | 5-section roadmap of the article | [Link](https://hannahstulberg.substack.com/p/tool-school-benchmarking-101-how-to-read-ai-model-report-cards) |
+| The Short Version | 63 | 2-minute framework: 4 benchmark categories, 3 questions to ask, relevance tiers, 4 things to watch | [Link](https://hannahstulberg.substack.com/i/192682753/the-short-version) |
+| The Pace of Change: 40 Models in 14 Months | 99 | Full timeline of model launches Jan 2025 - Mar 2026 across Anthropic, OpenAI, Google | [Link](https://hannahstulberg.substack.com/i/192682753/the-pace-of-change-40-models-in-14-months) |
+| Every Launch Changes What You Can Build | 125 | Why the accelerating pace matters for your work - build for the model coming in 6 months | [Link](https://hannahstulberg.substack.com/i/192682753/the-pace-of-change-40-models-in-14-months) |
+| Benchmarks 101 | 137 | What benchmarks actually measure, how models are scored, terms you need to know | [Link](https://hannahstulberg.substack.com/i/192682753/benchmarks-101) |
+| A High SAT Score Doesn't Make Someone a Great Colleague | 141 | SAT metaphor - benchmark scores are standardized tests for AI, each measures one narrow skill | [Link](https://hannahstulberg.substack.com/i/192682753/benchmarks-101) |
+| What a Benchmark Actually Is | 155 | Definition: standardized test for AI models - fixed questions, tasks with answers, or head-to-head | [Link](https://hannahstulberg.substack.com/i/192682753/benchmarks-101) |
+| Benchmarks Use One of 3 Grading Systems | 161 | Pass@1 (one attempt), Pass@k (multiple attempts), Elo rating (head-to-head via Chatbot Arena) | [Link](https://hannahstulberg.substack.com/i/192682753/benchmarks-101) |
+| There Are 4 Major Categories of Benchmarks | 177 | Knowledge & Reasoning, Coding, Reasoning, Agentic & Computer Use | [Link](https://hannahstulberg.substack.com/i/192682753/benchmarks-101) |
+| Why Only a Handful of Benchmarks Become Standard | 193 | 3 bars: hard enough, simple enough metric, interpretable to non-researchers | [Link](https://hannahstulberg.substack.com/i/192682753/benchmarks-101) |
+| The Benchmark Reference Table | 203 | Complete table of every major benchmark: category, year, creator, what it tests, scoring | [Link](https://hannahstulberg.substack.com/i/192682753/benchmarks-101) |
+| The Major Benchmarks | 226 | Deep dive on each benchmark with example cards | [Link](https://hannahstulberg.substack.com/i/192682753/benchmarks-101) |
+| Knowledge & Reasoning Benchmarks | 228 | MMLU (2020), GPQA Diamond (2023), HLE (2025), GDPval (2025) | [Link](https://hannahstulberg.substack.com/i/192682753/benchmarks-101) |
+| Coding Benchmarks | 256 | SWE-bench Verified (2024), SWE-bench Pro (2025), SWE-Lancer (2025), plus the real-world gap | [Link](https://hannahstulberg.substack.com/i/192682753/benchmarks-101) |
+| Reasoning Benchmarks | 284 | ARC-AGI-3 (2026) and ARC-AGI-2 (2025) - novel problem-solving the model has never seen | [Link](https://hannahstulberg.substack.com/i/192682753/benchmarks-101) |
+| Agentic & Computer Use Benchmarks | 300 | OSWorld, tau2-bench, BigLaw Bench, Terminal-Bench 2.0 - sustained professional work | [Link](https://hannahstulberg.substack.com/i/192682753/benchmarks-101) |
+| Why Benchmarks Expire | 326 | When everyone gets an A, the A stops meaning anything - saturation, contamination, optimization | [Link](https://hannahstulberg.substack.com/i/192682753/why-benchmarks-expire-when-everyone-gets-an-a-the-a-stops-meaning-anything) |
+| Models Improve Faster Than New Tests | 338 | Saturation: scores converge, spread disappears, test becomes noise | [Link](https://hannahstulberg.substack.com/i/192682753/why-benchmarks-expire-when-everyone-gets-an-a-the-a-stops-meaning-anything) |
+| Training Data Gets Contaminated | 344 | Contamination: models see test answers in training data - SWE-bench Verified example | [Link](https://hannahstulberg.substack.com/i/192682753/why-benchmarks-expire-when-everyone-gets-an-a-the-a-stops-meaning-anything) |
+| Optimization Pressure (Goodhart's Law) | 354 | When a measure becomes a target, it ceases to be a good measure | [Link](https://hannahstulberg.substack.com/i/192682753/why-benchmarks-expire-when-everyone-gets-an-a-the-a-stops-meaning-anything) |
+| The Cycle Compounds and Accelerates | 358 | ImageNet lasted 5 years, MMLU 3, SWE-bench Verified 2 - ARC-AGI-3's radical response | [Link](https://hannahstulberg.substack.com/i/192682753/why-benchmarks-expire-when-everyone-gets-an-a-the-a-stops-meaning-anything) |
+| Which Benchmarks Are Still Working Right Now? | 374 | 3 questions: How long public? Who created it? Scores still spread out? | [Link](https://hannahstulberg.substack.com/i/192682753/why-benchmarks-expire-when-everyone-gets-an-a-the-a-stops-meaning-anything) |
+| Where Each Benchmark Stands Right Now | 384 | Trust tiers: High (ARC-AGI-3, ARC-AGI-2, HLE, SWE-bench Pro, OSWorld, Terminal-Bench 2.0), Moderate, Low | [Link](https://hannahstulberg.substack.com/i/192682753/why-benchmarks-expire-when-everyone-gets-an-a-the-a-stops-meaning-anything) |
+| Where to Check Scores Yourself | 421 | 5 independent sources: Chatbot Arena, Artificial Analysis, ARC Prize, Scale AI, Stanford CRFM | [Link](https://hannahstulberg.substack.com/i/192682753/why-benchmarks-expire-when-everyone-gets-an-a-the-a-stops-meaning-anything) |
+| Apply What You've Learned: Read the Scorecard | 433 | Real benchmark table from Anthropic's Opus 4.6 launch - read and evaluate every line | [Link](https://hannahstulberg.substack.com/i/192682753/apply-what-youve-learned-you-can-now-read-the-scorecard) |
+| You Recognize Every Name on This Table | 452 | Applying benchmark knowledge to identify each test in the Opus 4.6 scorecard | [Link](https://hannahstulberg.substack.com/i/192682753/apply-what-youve-learned-you-can-now-read-the-scorecard) |
+| You Know What the Scores Actually Mean | 456 | Understanding pass@1 vs Elo rating in context | [Link](https://hannahstulberg.substack.com/i/192682753/apply-what-youve-learned-you-can-now-read-the-scorecard) |
+| You Can Evaluate How Relevant Every Score Is | 462 | Relevance assessment of each Opus 4.6 benchmark score with reasoning | [Link](https://hannahstulberg.substack.com/i/192682753/apply-what-youve-learned-you-can-now-read-the-scorecard) |
+| How to Read the Next Model Launch | 479 | Head-to-head comparison and what to watch for in any announcement | [Link](https://hannahstulberg.substack.com/i/192682753/how-to-read-the-next-model-launch) |
+| No Single Model Wins | 483 | Side-by-side comparison: Opus 4.6 vs Sonnet 4.6 vs GPT-5.4 vs Gemini 3.1 Pro | [Link](https://hannahstulberg.substack.com/i/192682753/how-to-read-the-next-model-launch) |
+| 4 Things to Watch for in Any Launch Announcement | 495 | Missing benchmarks, baseline comparisons, human preference vs benchmarks, methodology transparency | [Link](https://hannahstulberg.substack.com/i/192682753/how-to-read-the-next-model-launch) |
+| What the Scorecard Leaves Out: Cost | 523 | API pricing, tokens, input/output costs - the dimension most tables omit | [Link](https://hannahstulberg.substack.com/i/192682753/what-the-scorecard-leaves-out-the-sat-doesnt-tell-you-about-tuition) |
+| Same Scores, Wildly Different Prices | 539 | Output token pricing comparison across models, DeepSeek R1 cost advantage | [Link](https://hannahstulberg.substack.com/i/192682753/what-the-scorecard-leaves-out-the-sat-doesnt-tell-you-about-tuition) |
+| Cost-Adjusted Evaluation Is Coming | 551 | ARC-AGI-2 measures cost-per-task, Artificial Analysis price-performance rankings | [Link](https://hannahstulberg.substack.com/i/192682753/what-the-scorecard-leaves-out-the-sat-doesnt-tell-you-about-tuition) |
+| Reading Recent Model Launches | 559 | Informed reads of Opus 4.6, Sonnet 4.6, and GPT-5.4 launches | [Link](https://hannahstulberg.substack.com/i/192682753/reading-the-3-february-march-2026-launches) |
+| Best for What? At What Price? On Which Tests? | 581 | Summary: no single model wins across the board | [Link](https://hannahstulberg.substack.com/i/192682753/best-for-what-at-what-price-on-which-tests) |
+| You Can Read the Next Model Announcement Yourself | 587 | Closing recap of 5 learning outcomes and confidence statement | [Link](https://hannahstulberg.substack.com/i/192682753/you-can-read-the-next-model-announcement-yourself) |


### PR DESCRIPTION
Allows the learning assistant to apply repo frameworks to reader-provided artifacts and adds an engagement rule inviting readers to keep the conversation going. Includes session-start hook refresh and minor navigation updates across article indexes.